### PR TITLE
Add .js extension to block-content import

### DIFF
--- a/src/blockContentToNodes.js
+++ b/src/blockContentToNodes.js
@@ -1,5 +1,5 @@
 
-import internals from '@sanity/block-content-to-hyperscript/internals'
+import internals from '@sanity/block-content-to-hyperscript/internals.js'
 
 const { getImageUrl, blocksToNodes, getSerializers } = internals
 


### PR DESCRIPTION
Corrects issue with building SvelteKit applications